### PR TITLE
CIが動くように微調整

### DIFF
--- a/.tagpr
+++ b/.tagpr
@@ -45,4 +45,4 @@
 [tagpr]
 	vPrefix = true
 	releaseBranch = main
-	versionFile = version.go
+	versionFile = version/version.go

--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,3 @@
 module github.com/sacloud/go-template
 
-go 1.21
+go 1.23


### PR DESCRIPTION
- govulncheck + go1.21でのエラー回避のためにgo 1.23へアップグレード
- tagprが編集するバージョンファイルのパスを修正